### PR TITLE
Add creator stage name to SolutionInfo

### DIFF
--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -146,6 +146,7 @@ void SolutionBase::fillInfo(moveit_task_constructor_msgs::SolutionInfo& info, In
 	info.comment = this->comment();
 	const Introspection* ci = introspection;
 	info.stage_id = ci ? ci->stageId(this->creator()->me()) : 0;
+	info.creator_name = this->creator()->name();
 
 	const auto& markers = this->markers();
 	info.markers.resize(markers.size());
@@ -160,7 +161,6 @@ void SubTrajectory::fillMessage(moveit_task_constructor_msgs::Solution& msg, Int
 	if (trajectory())
 		trajectory()->getRobotTrajectoryMsg(t.trajectory);
 
-	t.creator_name = this->creator()->name();
 	this->end()->scene()->getPlanningSceneDiffMsg(t.scene_diff);
 }
 

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -160,6 +160,7 @@ void SubTrajectory::fillMessage(moveit_task_constructor_msgs::Solution& msg, Int
 	if (trajectory())
 		trajectory()->getRobotTrajectoryMsg(t.trajectory);
 
+	t.creator_name = this->creator()->name();
 	this->end()->scene()->getPlanningSceneDiffMsg(t.scene_diff);
 }
 

--- a/msgs/msg/SolutionInfo.msg
+++ b/msgs/msg/SolutionInfo.msg
@@ -10,5 +10,8 @@ string comment
 # id of stage that created this trajectory
 uint32 stage_id
 
+# name of the stage that created this trajectory
+string creator_name
+
 # markers, e.g. providing additional hints or illustrating failure
 visualization_msgs/Marker[] markers

--- a/msgs/msg/SubTrajectory.msg
+++ b/msgs/msg/SubTrajectory.msg
@@ -6,3 +6,6 @@ moveit_msgs/RobotTrajectory trajectory
 
 # planning scene of end state as diff w.r.t. start state
 moveit_msgs/PlanningScene scene_diff
+
+# Name of the stage that created this trajectory
+string creator_name

--- a/msgs/msg/SubTrajectory.msg
+++ b/msgs/msg/SubTrajectory.msg
@@ -6,6 +6,3 @@ moveit_msgs/RobotTrajectory trajectory
 
 # planning scene of end state as diff w.r.t. start state
 moveit_msgs/PlanningScene scene_diff
-
-# Name of the stage that created this trajectory
-string creator_name


### PR DESCRIPTION
In #162 , @v4hn suggested the option of executing the solution sequentially to execute custom functions. We tried using this in an application, but when stepping through the solution's subtrajectories, we are somewhat blind as the solution does not seem to contain any semantic cues by itself*. If it does, a student of mine and I could not find them. This is a complex piece of software.

This PR extends the subtrajectory message by the name of the stage that created it so that the user can tell which part of the task they are at and execute arbitrary code (e.g. gripper open/close, set I/O, change display, call service...) when desired. Naming stages appropriately seems to be the easiest way to implement what @v4hn called "the trivial way". 

Adding code hooks may be the proper way, but as mentioned in #162 there is no time frame on this feature, and this workaround is simple, lightweight and works in Python.

This does not need to be merged, it can just be a reference for whoever wants to execute solutions this way.

*edit: Yes, you could get the `stage_id` from the `SolutionInfo` of each trajectory and search through the `TaskDescription` to retrieve the name, but it is awkward.