### PR TITLE
Temporarily fix issues with execution of pick+place demo

### DIFF
--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -57,7 +57,7 @@ Connect::Connect(const std::string& name, const GroupPlannerVector& planners) : 
 
 	auto& p = properties();
 	p.declare<MergeMode>("merge_mode", WAYPOINTS, "merge mode");
-	p.declare<double>("max_distance", 1e-4, "maximally accepted distance between end and goal sate");
+	p.declare<double>("max_distance", 1e-2, "maximally accepted distance between end and goal sate");
 	p.declare<moveit_msgs::msg::Constraints>("path_constraints", moveit_msgs::msg::Constraints(),
 	                                         "constraints to maintain during trajectory");
 	properties().declare<TimeParameterizationPtr>("merge_time_parameterization",


### PR DESCRIPTION
- Connect stage: Relax validity check of reached end state
  Looks like ROS2 uses a more relaxed goal constraint threshold than ROS1.
For this reason, all end states reached by Connect solutions of pick+place demo
are rejected. This commit relaxes the max_distance threshold of Connect as well.
**MoveIt2 maintainers should check MoveIt2's goal constraint threshold and use a similar value in Connect stage.**
Fixes https://github.com/ros-planning/moveit_task_constructor/issues/540#issuecomment-1988323674

- Revert "Fix generation of Solution msg: consider backward operation"
This reverts commit 4aac679257fb91bed9174096761879d1f14182fc, because MoveIt2 is missing a port of https://github.com/ros-planning/moveit/pull/3538.
Fixes https://github.com/ros-planning/moveit2_tutorials/issues/881
