### PR TITLE
Fail early when Connect stage start state is in collision

### DIFF
--- a/demo/config/panda_config.yaml
+++ b/demo/config/panda_config.yaml
@@ -44,5 +44,5 @@
     approach_object_max_dist: 0.15
 
     # Valid height range when lifting an object after pick
-    lift_object_min_dist: 0.01
-    lift_object_max_dist: 0.1
+    lift_object_min_dist: 0.1
+    lift_object_max_dist: 0.2

--- a/demo/src/pick_place_task.cpp
+++ b/demo/src/pick_place_task.cpp
@@ -95,6 +95,10 @@ void setupDemoScene(const pick_place_task_demo::Params& params) {
 	moveit::planning_interface::PlanningSceneInterface psi;
 	if (params.spawn_table)
 		spawnObject(psi, createTable(params));
+	pick_place_task_demo::Params my_params(params);
+	my_params.table_pose[2] += 0.4;
+	my_params.table_name = "MyTable";
+	spawnObject(psi, createTable(my_params));
 	spawnObject(psi, createObject(params));
 }
 
@@ -265,7 +269,8 @@ bool PickPlaceTask::init(const rclcpp::Node::SharedPtr& node, const pick_place_t
 		 ***************************************************/
 		{
 			auto stage = std::make_unique<stages::ModifyPlanningScene>("allow collision (object,support)");
-			stage->allowCollisions({ params.object_name }, { params.surface_link }, true);
+			stage->allowCollisions({ params.object_name }, { params.surface_link }, false);
+			stage->allowCollisions({ params.object_name }, { "MyTable" }, true);
 			grasp->insert(std::move(stage));
 		}
 
@@ -293,6 +298,7 @@ bool PickPlaceTask::init(const rclcpp::Node::SharedPtr& node, const pick_place_t
 		{
 			auto stage = std::make_unique<stages::ModifyPlanningScene>("forbid collision (object,surface)");
 			stage->allowCollisions({ params.object_name }, { params.surface_link }, false);
+			stage->allowCollisions({ params.object_name }, { "MyTable" }, false);
 			grasp->insert(std::move(stage));
 		}
 


### PR DESCRIPTION
I have a project that I'm working on that was having motion planning failures when the start state of a Connect stage was in collision. My MoveIt config is on Humble and was missing the request_adapter `default_planner_request_adapters/FixStartStateBounds` so I was not getting any info other than planning failed and the terminal was spammed with `Motion planning start tree could not be initialized!` for several seconds.

After I added the request_adapter `default_planner_request_adapters/FixStartStateBounds` I could see which links were causing the failure but the Connect stage still attempted to search for a long period of time even though it was not possible to find a solution (I believe the amount of time is  `# of connecting states * myConnectStage.setTimeout(Value)`).

This PR is a bit of a hack but I wanted to see if you think checking the start state for collisions before planning would be a useful addition. I have modified the demo program to highlight the issue if you would like to test it out. I was surprised that I could not replicate the issue by simply removing the [Forbid collision (object support) stage](https://github.com/MarqRazz/moveit_task_constructor/blob/humble/demo/src/pick_place_task.cpp#L290-L297) so I added a second table to the scene that causes collision after the cylinder is lifted.

Right now my proposed solution is failing much faster but still not working as expected because it is not properly reporting the failure's to the Rviz MTC widget.