### PR TITLE
Fix `MoveRelative` potentially empty trajectory issue

### DIFF
--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -291,7 +291,8 @@ bool MoveRelative::compute(const InterfaceState& state, planning_scene::Planning
 		if (!success)
 			comment = result.message;
 
-		if (robot_trajectory) {  // the following requires a robot_trajectory returned from planning
+		if (robot_trajectory && robot_trajectory->getWayPointCount() > 0) {  // the following requires a robot_trajectory
+			                                                                  // returned from planning
 			moveit::core::RobotStatePtr& reached_state = robot_trajectory->getLastWayPointPtr();
 			reached_state->updateLinkTransforms();
 			const Eigen::Isometry3d& reached_pose = reached_state->getGlobalLinkTransform(link) * offset;

--- a/core/src/stages/move_relative.cpp
+++ b/core/src/stages/move_relative.cpp
@@ -327,7 +327,7 @@ bool MoveRelative::compute(const InterfaceState& state, planning_scene::Planning
 	}
 
 	// store result
-	if (robot_trajectory) {
+	if (robot_trajectory && robot_trajectory->getWayPointCount() > 0) {
 		scene->setCurrentState(robot_trajectory->getLastWayPoint());
 		if (dir == Interface::BACKWARD)
 			robot_trajectory->reverse();


### PR DESCRIPTION
We have run into an issue a few times with `MoveRelative` relative that causes a crash. If the ``PlannerInterface` implementation returns a trajectory with no waypoints, but a non-null `robot_trajectory`, then the back of an empty vector is accessed via `robot_trajectory->getLastWayPointPtr()` leading to a crash. 

A potential fix is to consider empty trajectories as a failed plan. We run into this issue frequently when the robot starts in or very close to a collision.     