### PR TITLE
Reduce preempt stop time in stages

### DIFF
--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -62,7 +62,6 @@ class PreemptStageException : public std::exception
 {
 public:
 	explicit PreemptStageException() {}
-	const char* what() const noexcept override { return ""; }
 };
 
 class ContainerBase;
@@ -171,7 +170,9 @@ public:
 	/** compute cost for solution through configured CostTerm */
 	void computeCost(const InterfaceState& from, const InterfaceState& to, SolutionBase& solution);
 
-	void setPreemptRequestedMember(const std::atomic<bool>* preempt_requested);
+	void setPreemptRequestedMember(const std::atomic<bool>* preempt_requested) {
+		preempt_requested_ = preempt_requested;
+	}
 	bool preempted() const { return preempt_requested_ != nullptr && *preempt_requested_; }
 
 protected:

--- a/core/include/moveit/task_constructor/stage_p.h
+++ b/core/include/moveit/task_constructor/stage_p.h
@@ -62,10 +62,7 @@ class PreemptStageException : public std::exception
 {
 public:
 	explicit PreemptStageException() {}
-	const char* what() const noexcept override {
-		static const char* msg = "";
-		return msg;
-	}
+	const char* what() const noexcept override { return ""; }
 };
 
 class ContainerBase;
@@ -174,9 +171,8 @@ public:
 	/** compute cost for solution through configured CostTerm */
 	void computeCost(const InterfaceState& from, const InterfaceState& to, SolutionBase& solution);
 
-	void setPreemptedCheck(const std::atomic<bool>* preempt_requested);
-	/// is the stage preempted ? defaults to false
-	bool preempted() const;
+	void setPreemptRequestedMember(const std::atomic<bool>* preempt_requested);
+	bool preempted() const { return preempt_requested_ != nullptr && *preempt_requested_; }
 
 protected:
 	StagePrivate& operator=(StagePrivate&& other);

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -130,6 +130,7 @@ public:
 	/// interrupt current planning
 	void preempt();
 	void resetPreemptRequest();
+	bool isPreempted();
 	/// execute solution, return the result
 	moveit::core::MoveItErrorCode execute(const SolutionBase& s);
 

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -130,7 +130,6 @@ public:
 	/// interrupt current planning
 	void preempt();
 	void resetPreemptRequest();
-	bool isPreempted();
 	/// execute solution, return the result
 	moveit::core::MoveItErrorCode execute(const SolutionBase& s);
 

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -102,7 +102,8 @@ StagePrivate::StagePrivate(Stage* me, const std::string& name)
   , cost_term_{ std::make_unique<CostTerm>() }
   , total_compute_time_{}
   , parent_{ nullptr }
-  , introspection_{ nullptr } {}
+  , introspection_{ nullptr }
+  , preempt_requested_{ nullptr } {}
 
 StagePrivate& StagePrivate::operator=(StagePrivate&& other) {
 	assert(typeid(*this) == typeid(other));
@@ -303,6 +304,17 @@ void StagePrivate::computeCost(const InterfaceState& from, const InterfaceState&
 	} else if (!comment.empty()) {
 		solution.setComment(comment);
 	}
+}
+
+void StagePrivate::setPreemptedCheck(const std::atomic<bool>* preempt_requested) {
+	preempt_requested_ = preempt_requested;
+}
+
+bool StagePrivate::preempted() const {
+	if (preempt_requested_)
+		return *preempt_requested_;
+
+	return false;
 }
 
 Stage::Stage(StagePrivate* impl) : pimpl_(impl) {

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -306,15 +306,8 @@ void StagePrivate::computeCost(const InterfaceState& from, const InterfaceState&
 	}
 }
 
-void StagePrivate::setPreemptedCheck(const std::atomic<bool>* preempt_requested) {
+void StagePrivate::setPreemptRequestedMember(const std::atomic<bool>* preempt_requested) {
 	preempt_requested_ = preempt_requested;
-}
-
-bool StagePrivate::preempted() const {
-	if (preempt_requested_)
-		return *preempt_requested_;
-
-	return false;
 }
 
 Stage::Stage(StagePrivate* impl) : pimpl_(impl) {

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -306,10 +306,6 @@ void StagePrivate::computeCost(const InterfaceState& from, const InterfaceState&
 	}
 }
 
-void StagePrivate::setPreemptRequestedMember(const std::atomic<bool>* preempt_requested) {
-	preempt_requested_ = preempt_requested;
-}
-
 Stage::Stage(StagePrivate* impl) : pimpl_(impl) {
 	assert(impl);
 	auto& p = properties();

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -218,7 +218,7 @@ void Task::init() {
 	impl->traverseStages(
 	    [introspection, impl](Stage& stage, int /*depth*/) {
 		    stage.pimpl()->setIntrospection(introspection);
-		    stage.pimpl()->setPreemptedCheck(&impl->preempt_requested_);
+		    stage.pimpl()->setPreemptRequestedMember(&impl->preempt_requested_);
 		    return true;
 	    },
 	    1, UINT_MAX);
@@ -277,10 +277,6 @@ void Task::preempt() {
 
 void Task::resetPreemptRequest() {
 	pimpl()->preempt_requested_ = false;
-}
-
-bool Task::isPreempted() {
-	return pimpl()->preempt_requested_;
 }
 
 moveit::core::MoveItErrorCode Task::execute(const SolutionBase& s) {

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -213,11 +213,12 @@ void Task::init() {
 	// task expects its wrapped child to push to both ends, this triggers interface resolution
 	stages()->pimpl()->resolveInterface(InterfaceFlags({ GENERATE }));
 
-	// provide introspection instance to all stages
+	// provide introspection instance and prempted requested to all stages
 	auto* introspection = impl->introspection_.get();
 	impl->traverseStages(
-	    [introspection](Stage& stage, int /*depth*/) {
+	    [introspection, impl](Stage& stage, int /*depth*/) {
 		    stage.pimpl()->setIntrospection(introspection);
+		    stage.pimpl()->setPreemptedCheck(&impl->preempt_requested_);
 		    return true;
 	    },
 	    1, UINT_MAX);
@@ -232,7 +233,11 @@ bool Task::canCompute() const {
 }
 
 void Task::compute() {
-	stages()->pimpl()->runCompute();
+	try {
+		stages()->pimpl()->runCompute();
+	} catch (const PreemptStageException& e) {
+		// do nothing, needed for early stop
+	}
 }
 
 moveit::core::MoveItErrorCode Task::plan(size_t max_solutions) {
@@ -272,6 +277,10 @@ void Task::preempt() {
 
 void Task::resetPreemptRequest() {
 	pimpl()->preempt_requested_ = false;
+}
+
+bool Task::isPreempted() {
+	return pimpl()->preempt_requested_;
 }
 
 moveit::core::MoveItErrorCode Task::execute(const SolutionBase& s) {

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -213,7 +213,7 @@ void Task::init() {
 	// task expects its wrapped child to push to both ends, this triggers interface resolution
 	stages()->pimpl()->resolveInterface(InterfaceFlags({ GENERATE }));
 
-	// provide introspection instance and prempted requested to all stages
+	// provide introspection instance and preempt_requested to all stages
 	auto* introspection = impl->introspection_.get();
 	impl->traverseStages(
 	    [introspection, impl](Stage& stage, int /*depth*/) {

--- a/core/test/stage_mockups.h
+++ b/core/test/stage_mockups.h
@@ -65,6 +65,7 @@ struct GeneratorMockup : public Generator
 	void init(const moveit::core::RobotModelConstPtr& robot_model) override;
 	bool canCompute() const override;
 	void compute() override;
+	virtual void reset() override { runs_ = 0; };
 };
 
 struct MonitoringGeneratorMockup : public MonitoringGenerator
@@ -81,6 +82,7 @@ struct MonitoringGeneratorMockup : public MonitoringGenerator
 	bool canCompute() const override { return false; }
 	void compute() override {}
 	void onNewSolution(const SolutionBase& s) override;
+	virtual void reset() override { runs_ = 0; };
 };
 
 struct ConnectMockup : public Connecting
@@ -97,6 +99,7 @@ struct ConnectMockup : public Connecting
 	using Connecting::compatible;  // make this accessible for testing
 
 	void compute(const InterfaceState& from, const InterfaceState& to) override;
+	virtual void reset() override { runs_ = 0; };
 };
 
 struct PropagatorMockup : public PropagatingEitherWay
@@ -113,6 +116,7 @@ struct PropagatorMockup : public PropagatingEitherWay
 
 	void computeForward(const InterfaceState& from) override;
 	void computeBackward(const InterfaceState& to) override;
+	virtual void reset() override { runs_ = 0; };
 };
 
 struct ForwardMockup : public PropagatorMockup

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -702,17 +702,10 @@ TEST_F(TaskTestBase, preempt) {
 	EXPECT_EQ(fwd2->runs_, 0u);
 	EXPECT_TRUE(t.plan(1));  // make sure the preempt request has been resetted on the previous call to plan()
 
-	// prempt in between stage computation
-	// Failing stage(s):
-	// 0  - ←   0 →   -  0 / task pipeline
-	//    1  - ←   1 →   -  0 / GEN1
-	//    -  0 →   1 →   -  1 / FWD1
-	//    -  1 →   0 →   -  0 / FWD2
 	t.reset();
-	resetMockupIds();
 	{
 		std::thread thread{ [&ec, this] { ec = t.plan(1); } };
-		std::this_thread::sleep_for(timeout);
+		std::this_thread::sleep_for(timeout / 2.0);
 		t.preempt();
 		thread.join();
 	}

--- a/core/test/test_container.cpp
+++ b/core/test/test_container.cpp
@@ -674,21 +674,20 @@ TEST(Task, timeout) {
 }
 
 // https://github.com/moveit/moveit_task_constructor/pull/597
+// https://github.com/moveit/moveit_task_constructor/pull/598
 // start planning in another thread, then preempt it in this thread
-TEST(Task, preempt) {
+TEST_F(TaskTestBase, preempt) {
 	moveit::core::MoveItErrorCode ec;
 	resetMockupIds();
 
-	Task t;
-	t.setRobotModel(getModel());
-
 	auto timeout = std::chrono::milliseconds(10);
-	t.add(std::make_unique<GeneratorMockup>(PredefinedCosts::constant(0.0)));
-	t.add(std::make_unique<TimedForwardMockup>(timeout));
+	auto gen1 = add(t, new GeneratorMockup(PredefinedCosts::constant(0.0)));
+	auto fwd1 = add(t, new TimedForwardMockup(timeout));
+	auto fwd2 = add(t, new TimedForwardMockup(timeout));
 
 	// preempt before preempt_request_ is reset in plan()
 	{
-		std::thread thread{ [&ec, &t, timeout] {
+		std::thread thread{ [&ec, this, timeout] {
 			std::this_thread::sleep_for(timeout);
 			ec = t.plan(1);
 		} };
@@ -698,5 +697,30 @@ TEST(Task, preempt) {
 
 	EXPECT_EQ(ec, moveit::core::MoveItErrorCode::PREEMPTED);
 	EXPECT_EQ(t.solutions().size(), 0u);
+	EXPECT_EQ(gen1->runs_, 0u);
+	EXPECT_EQ(fwd1->runs_, 0u);
+	EXPECT_EQ(fwd2->runs_, 0u);
+	EXPECT_TRUE(t.plan(1));  // make sure the preempt request has been resetted on the previous call to plan()
+
+	// prempt in between stage computation
+	// Failing stage(s):
+	// 0  - ←   0 →   -  0 / task pipeline
+	//    1  - ←   1 →   -  0 / GEN1
+	//    -  0 →   1 →   -  1 / FWD1
+	//    -  1 →   0 →   -  0 / FWD2
+	t.reset();
+	resetMockupIds();
+	{
+		std::thread thread{ [&ec, this] { ec = t.plan(1); } };
+		std::this_thread::sleep_for(timeout);
+		t.preempt();
+		thread.join();
+	}
+
+	EXPECT_EQ(ec, moveit::core::MoveItErrorCode::PREEMPTED);
+	EXPECT_EQ(t.solutions().size(), 0u);
+	EXPECT_EQ(gen1->runs_, 1u);
+	EXPECT_EQ(fwd1->runs_, 1u);
+	EXPECT_EQ(fwd2->runs_, 0u);
 	EXPECT_TRUE(t.plan(1));  // make sure the preempt request has been resetted on the previous call to plan()
 }


### PR DESCRIPTION
This is a follow up to #597. To reduce time when preempting a task for each stages.

Stages now checks if there has been a preempt request before doing the `compute()` method. Let me know if there would be a cleaner way to achieve this.

This does not preempt a stage that has already began the compute() method.