### PR TITLE
clean up dependencies for rviz_marker_tools

### DIFF
--- a/rviz_marker_tools/CMakeLists.txt
+++ b/rviz_marker_tools/CMakeLists.txt
@@ -3,11 +3,14 @@ project(rviz_marker_tools)
 
 find_package(catkin REQUIRED COMPONENTS
 	geometry_msgs
-	visualization_msgs
 	roscpp
+	std_msgs
 	tf2_eigen
+	visualization_msgs
 )
-find_package(urdfdom REQUIRED)
+find_package(Eigen3 REQUIRED)
+
+find_package(urdfdom_headers REQUIRED)
 
 catkin_package(
 	LIBRARIES
@@ -16,10 +19,10 @@ catkin_package(
 		include
 	CATKIN_DEPENDS
 		geometry_msgs
+		std_msgs
 		visualization_msgs
-		roscpp
 	DEPENDS
-		urdfdom
+		EIGEN3
 )
 
 set(PROJECT_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/${PROJECT_NAME})
@@ -35,7 +38,11 @@ add_library(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
-target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE ${catkin_INCLUDE_DIRS})
+target_include_directories(${PROJECT_NAME} SYSTEM PRIVATE
+   ${catkin_INCLUDE_DIRS}
+   ${urdfdom_headers_INCLUDE_DIRS}
+   ${EIGEN3_INCLUDE_DIR}
+)
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 
 install(DIRECTORY include/ DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION})

--- a/rviz_marker_tools/include/rviz_marker_tools/marker_creation.h
+++ b/rviz_marker_tools/include/rviz_marker_tools/marker_creation.h
@@ -1,8 +1,9 @@
 #pragma once
 
-#include <visualization_msgs/Marker.h>
-#include <geometry_msgs/PoseStamped.h>
 #include <Eigen/Geometry>
+#include <geometry_msgs/PoseStamped.h>
+#include <std_msgs/ColorRGBA.h>
+#include <visualization_msgs/Marker.h>
 
 namespace urdf {
 class Geometry;

--- a/rviz_marker_tools/package.xml
+++ b/rviz_marker_tools/package.xml
@@ -9,9 +9,26 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
-	<depend>visualization_msgs</depend>
-	<depend>geometry_msgs</depend>
-	<depend>roscpp</depend>
-	<depend>tf2_eigen</depend>
-	<depend>liburdfdom-dev</depend>
+	<build_depend>eigen</build_depend>
+	<build_export_depend>eigen</build_export_depend>
+
+	<build_depend>geometry_msgs</build_depend>
+	<build_export_depend>geometry_msgs</build_export_depend>
+	<exec_depend>geometry_msgs</exec_depend>
+
+	<build_depend>liburdfdom-headers-dev</build_depend>
+
+	<build_depend>roscpp</build_depend>
+	<exec_depend>roscpp</exec_depend>
+
+	<build_depend>std_msgs</build_depend>
+	<build_export_depend>std_msgs</build_export_depend>
+	<exec_depend>std_msgs</exec_depend>
+
+	<build_depend>tf2_eigen</build_depend>
+	<exec_depend>tf2_eigen</exec_depend>
+
+	<build_depend>visualization_msgs</build_depend>
+	<build_export_depend>visualization_msgs</build_export_depend>
+	<exec_depend>visualization_msgs</exec_depend>
 </package>

--- a/rviz_marker_tools/package.xml
+++ b/rviz_marker_tools/package.xml
@@ -12,23 +12,17 @@
 	<build_depend>eigen</build_depend>
 	<build_export_depend>eigen</build_export_depend>
 
-	<build_depend>geometry_msgs</build_depend>
-	<build_export_depend>geometry_msgs</build_export_depend>
-	<exec_depend>geometry_msgs</exec_depend>
+	<depend>geometry_msgs</depend>
 
 	<build_depend>liburdfdom-headers-dev</build_depend>
 
 	<build_depend>roscpp</build_depend>
 	<exec_depend>roscpp</exec_depend>
 
-	<build_depend>std_msgs</build_depend>
-	<build_export_depend>std_msgs</build_export_depend>
-	<exec_depend>std_msgs</exec_depend>
+	<depend>std_msgs</depend>
 
 	<build_depend>tf2_eigen</build_depend>
 	<exec_depend>tf2_eigen</exec_depend>
 
-	<build_depend>visualization_msgs</build_depend>
-	<build_export_depend>visualization_msgs</build_export_depend>
-	<exec_depend>visualization_msgs</exec_depend>
+	<depend>visualization_msgs</depend>
 </package>


### PR DESCRIPTION
`liburdfdom-dev` is not actually used. Only `liburdfdom-headers-dev`.

I cleaned up a few other things along the way while working on building packages for it in [my ros-o github builder](https://v4hn.github.io/ros-o-builder/).
