### PR TITLE
Wrapper FMT header for compatibility

### DIFF
--- a/core/include/moveit/task_constructor/fmt_p.h
+++ b/core/include/moveit/task_constructor/fmt_p.h
@@ -1,0 +1,49 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2024, University of Hamburg
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Authors: Michael Goerner
+   Desc:    Thin wrapper around fmt includes to provide Eigen formatters for fmt9
+*/
+
+#pragma once
+
+#include <Eigen/Core>
+#include <fmt/core.h>
+#include <fmt/ostream.h>
+
+#if FMT_VERSION >= 90000
+template <typename T>
+struct fmt::formatter<T, std::enable_if_t<std::is_base_of_v<Eigen::DenseBase<T>, T>, char>> : ostream_formatter
+{};
+#endif

--- a/core/python/bindings/src/solvers.cpp
+++ b/core/python/bindings/src/solvers.cpp
@@ -37,8 +37,8 @@
 #include <moveit/task_constructor/solvers/pipeline_planner.h>
 #include <moveit/task_constructor/solvers/joint_interpolation.h>
 #include <moveit/task_constructor/solvers/multi_planner.h>
+#include <moveit/task_constructor/fmt_p.h>
 #include <moveit_msgs/WorkspaceParameters.h>
-#include <fmt/core.h>
 #include "utils.h"
 
 namespace py = pybind11;

--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -37,6 +37,7 @@
 #include <moveit/task_constructor/container_p.h>
 #include <moveit/task_constructor/introspection.h>
 #include <moveit/task_constructor/merge.h>
+#include <moveit/task_constructor/fmt_p.h>
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
 
@@ -46,7 +47,6 @@
 #include <iostream>
 #include <algorithm>
 #include <boost/range/adaptor/reversed.hpp>
-#include <fmt/core.h>
 #include <functional>
 
 using namespace std::placeholders;

--- a/core/src/cost_terms.cpp
+++ b/core/src/cost_terms.cpp
@@ -36,6 +36,7 @@
 
 #include <moveit/task_constructor/cost_terms.h>
 #include <moveit/task_constructor/stage.h>
+#include <moveit/task_constructor/fmt_p.h>
 
 #include <moveit/collision_detection/collision_common.h>
 #include <moveit/robot_trajectory/robot_trajectory.h>
@@ -44,7 +45,6 @@
 
 #include <Eigen/Geometry>
 
-#include <fmt/core.h>
 #include <utility>
 
 namespace moveit {

--- a/core/src/properties.cpp
+++ b/core/src/properties.cpp
@@ -37,8 +37,7 @@
 */
 
 #include <moveit/task_constructor/properties.h>
-#include <fmt/core.h>
-#include <fmt/ostream.h>
+#include <moveit/task_constructor/fmt_p.h>
 #include <functional>
 #include <ros/console.h>
 

--- a/core/src/stage.cpp
+++ b/core/src/stage.cpp
@@ -38,11 +38,11 @@
 #include <moveit/task_constructor/stage_p.h>
 #include <moveit/task_constructor/container_p.h>
 #include <moveit/task_constructor/introspection.h>
+#include <moveit/task_constructor/fmt_p.h>
 
 #include <moveit/planning_scene/planning_scene.h>
 
 #include <ros/console.h>
-#include <fmt/core.h>
 
 #include <iostream>
 #include <iomanip>

--- a/core/src/stages/compute_ik.cpp
+++ b/core/src/stages/compute_ik.cpp
@@ -37,6 +37,7 @@
 #include <moveit/task_constructor/stages/compute_ik.h>
 #include <moveit/task_constructor/storage.h>
 #include <moveit/task_constructor/marker_tools.h>
+#include <moveit/task_constructor/fmt_p.h>
 
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/robot_state/conversions.h>
@@ -48,7 +49,6 @@
 #include <functional>
 #include <iterator>
 #include <ros/console.h>
-#include <fmt/core.h>
 
 namespace moveit {
 namespace task_constructor {

--- a/core/src/stages/connect.cpp
+++ b/core/src/stages/connect.cpp
@@ -39,11 +39,10 @@
 #include <moveit/task_constructor/stages/connect.h>
 #include <moveit/task_constructor/merge.h>
 #include <moveit/task_constructor/cost_terms.h>
+#include <moveit/task_constructor/fmt_p.h>
 
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/trajectory_processing/time_optimal_trajectory_generation.h>
-#include <fmt/core.h>
-#include <fmt/ostream.h>
 
 using namespace trajectory_processing;
 

--- a/core/src/stages/fix_collision_objects.cpp
+++ b/core/src/stages/fix_collision_objects.cpp
@@ -38,6 +38,7 @@
 
 #include <moveit/task_constructor/stages/fix_collision_objects.h>
 #include <moveit/task_constructor/storage.h>
+#include <moveit/task_constructor/fmt_p.h>
 
 #include <moveit/planning_scene/planning_scene.h>
 #include <moveit/task_constructor/cost_terms.h>
@@ -46,7 +47,6 @@
 #include <Eigen/Geometry>
 #include <tf2_eigen/tf2_eigen.h>
 #include <ros/console.h>
-#include <fmt/core.h>
 
 namespace vm = visualization_msgs;
 namespace cd = collision_detection;

--- a/core/src/stages/modify_planning_scene.cpp
+++ b/core/src/stages/modify_planning_scene.cpp
@@ -39,9 +39,9 @@
 #include <moveit/task_constructor/stages/modify_planning_scene.h>
 #include <moveit/task_constructor/storage.h>
 #include <moveit/task_constructor/cost_terms.h>
+#include <moveit/task_constructor/fmt_p.h>
 
 #include <moveit/planning_scene/planning_scene.h>
-#include <fmt/core.h>
 
 namespace moveit {
 namespace task_constructor {


### PR DESCRIPTION
for special eigen formatter, which is not available in fmt9+ (found on Debian testing).

https://github.com/fmtlib/fmt/issues/3465
https://stackoverflow.com/a/73755864/21260084

@rhaschke Not sure whether you are ok with the generic wrapper header as you usually argue for minimal includes. The concrete issue currently only affects a single location where an Eigen datatype is formatted. But I believe as we use libfmt all over the place (as you introduced at some point), I would also expect to be able to format Eigen datastructures everywhere without additional includes & helpers.