### PR TITLE
[WIP] Quick access of stages by id/index

### DIFF
--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -98,6 +98,9 @@ public:
 	void insert(Stage::pointer&& stage, int before = -1) override;
 	void clear() final;
 
+	/// creates a flat buffer of stages in breath-first search order
+	void fillFlatBufferStages();
+
 	/// enable introspection publishing for use with rviz
 	void enableIntrospection(bool enable = true);
 	Introspection& introspection();
@@ -150,6 +153,7 @@ public:
 	/// access stage tree
 	ContainerBase* stages();
 	const ContainerBase* stages() const;
+	const ContainerBase* stages(uint32_t stage_id) const;
 
 	/// properties access
 	PropertyMap& properties();
@@ -165,6 +169,8 @@ protected:
 
 private:
 	using WrapperBase::init;
+
+	std::vector<const ContainerBase*> bfs_stages_;  // breadth-first search
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Task& task) {

--- a/core/include/moveit/task_constructor/task_p.h
+++ b/core/include/moveit/task_constructor/task_p.h
@@ -58,6 +58,7 @@ public:
 
 	const std::string& ns() const { return ns_; }
 	const ContainerBase* stages() const;
+	const ContainerBase* stages(uint32_t stage_id) const;
 
 private:
 	std::string ns_;


### PR DESCRIPTION
This is somewhat related to #194. For pre-execution purposes.

We can already achieve this without any modification to the current code. This PR is just for demonstration.

1- Create a flat buffer of stages in BFS/DFS order
2- The indexes represents (minus 1) the given `stage_id` from [SolutionInfo.msg](.msgs/msg/SolutionInfo.msg)
3- Use the stage_id to get the stage from the vector directly in O(1) complexity
4- You can retrieve your properties

I think the `stage_id` is primarily used for RViz, thus instropection must be enabled. 

```cpp
task->fillFlatBufferStages();
task->plan();

...

// introspection needed to populate message
moveit_task_constructor_msgs::Solution solution_msg;
task.solutions().front()->toMsg(solution_msg, &task.introspection());

for (std::size_t i = 0; i < solution_msg.sub_trajectory.size(); ++i)
{
    auto& sub_trajectory = solution_msg.sub_trajectory[i];

    uint32_t id = sub_trajectory.info.id;
    uint32_t stage_id = sub_trajectory.info.stage_id;

    // retrieve stage
    const moveit::task_constructor::Stage* stage = task.stages(stage_id - 1);
    if(!stage)
        throw std::runtime_error("explosion")
    
    // retrieve properties
    int my_property = stage->properties().get<int>("my-awesome-property")
}


```

----

Would there be any interest in adding this sort of behavior inside MTC ?

If yes then:
- Could be always on, or enabled by the user.
- Must work without introspection, needs a new ID ?

If no:
- Must work without introspection, needs a new ID ?




