### PR TITLE
Silent pybind11 warning

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         env:
+          - IMAGE: jammy-ci
           - IMAGE: noetic-source
             NAME: ccov
             TARGET_CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="--coverage"
@@ -38,7 +39,7 @@ jobs:
       CATKIN_LINT: true
       CLANG_TIDY_ARGS: -quiet -export-fixes ${{ github.workspace }}/.work/clang-tidy-fixes.yaml
       DOCKER_IMAGE: moveit/moveit:${{ matrix.env.IMAGE }}
-      UNDERLAY: /root/ws_moveit/install
+      UNDERLAY: ${{ matrix.env.IMAGE != 'jammy-ci' && '/root/ws_moveit/install' || '' }}
       DOWNSTREAM_WORKSPACE: "github:ubi-agni/mtc_demos#master"
       CCACHE_DIR: ${{ github.workspace }}/.ccache
       BASEDIR: ${{ github.workspace }}/.work

--- a/core/cmake/pybind11.cmake.in
+++ b/core/cmake/pybind11.cmake.in
@@ -1,5 +1,5 @@
 # pybind11 must use the ROS python version
-set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
+set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION})
 
 if(@INSTALLSPACE@)
 	include(${CMAKE_CURRENT_LIST_DIR}/pybind11Config.cmake)

--- a/core/python/CMakeLists.txt
+++ b/core/python/CMakeLists.txt
@@ -1,7 +1,7 @@
 # We rely on pybind11's smart_holder branch imported pybind11 via git submodule
 
 # pybind11 must use the ROS python version
-set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION_STRING})
+set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION})
 
 # Use minimum-size optimization for pybind11 bindings
 add_compile_options("-Os")

--- a/core/python/bindings/src/core.cpp
+++ b/core/python/bindings/src/core.cpp
@@ -414,6 +414,7 @@ void export_core(pybind11::module& m) {
 
 	    .def("loadRobotModel", &Task::loadRobotModel, "robot_description"_a = "robot_description",
 	         "Load robot model from given ROS parameter")
+	    .def("setRobotModel", &Task::setRobotModel, "robot_model"_a, "Set the robot model for the task")
 	    .def("getRobotModel", &Task::getRobotModel)
 	    .def("enableIntrospection", &Task::enableIntrospection, "enabled"_a = true,
 	         "Enable publishing intermediate results for inspection in ``rviz``")


### PR DESCRIPTION
On Jammy, pybind11 complains with:
```
CMake Warning at python/pybind11/tools/pybind11Tools.cmake:24 (message):
  Set PYBIND11_PYTHON_VERSION to search for a specific version, not
  PYTHON_VERSION (which is an output).  Assuming that is what you meant to do
  and continuing anyway.
```
Looks like `PYTHON_VERSION_STRING` is not defined anymore.