### PR TITLE
[wip] Fix duplicate scenes in Solution.msg in forward planning

### DIFF
--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -231,10 +231,7 @@ void SubTrajectory::appendTo(moveit_task_constructor_msgs::Solution& msg, Intros
 	if (trajectory())
 		trajectory()->getRobotTrajectoryMsg(t.trajectory);
 
-	if (this->end()->scene()->getParent() == this->start()->scene())
-		this->end()->scene()->getPlanningSceneDiffMsg(t.scene_diff);
-	else
-		this->end()->scene()->getPlanningSceneMsg(t.scene_diff);
+	this->end()->scene()->getPlanningSceneDiffMsg(t.scene_diff);
 }
 
 double SubTrajectory::computeCost(const CostTerm& f, std::string& comment) const {

--- a/core/src/storage.cpp
+++ b/core/src/storage.cpp
@@ -231,7 +231,11 @@ void SubTrajectory::appendTo(moveit_task_constructor_msgs::Solution& msg, Intros
 	if (trajectory())
 		trajectory()->getRobotTrajectoryMsg(t.trajectory);
 
-	this->end()->scene()->getPlanningSceneDiffMsg(t.scene_diff);
+	if (this->end()->scene()->getParent() == this->start()->scene() ||  // diff
+	    this->end()->scene() == this->start()->scene())  // identical (from generator)
+		this->end()->scene()->getPlanningSceneDiffMsg(t.scene_diff);
+	else
+		this->end()->scene()->getPlanningSceneMsg(t.scene_diff);
 }
 
 double SubTrajectory::computeCost(const CostTerm& f, std::string& comment) const {

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -41,6 +41,7 @@ if (CATKIN_ENABLE_TESTING)
 	mtc_add_gmock(test_pruning.cpp)
 	mtc_add_gtest(test_properties.cpp)
 	mtc_add_gtest(test_cost_terms.cpp)
+	mtc_add_gtest(test_storage.cpp)
 
 	mtc_add_gmock(test_fallback.cpp)
 	mtc_add_gmock(test_cost_queue.cpp)

--- a/core/test/test_storage.cpp
+++ b/core/test/test_storage.cpp
@@ -1,0 +1,35 @@
+#include "models.h"
+
+#include <moveit/task_constructor/task.h>
+#include <moveit/task_constructor/stages/fixed_state.h>
+
+#include <moveit/planning_scene/planning_scene.h>
+
+#include <ros/console.h>
+#include <gtest/gtest.h>
+
+using namespace moveit::task_constructor;
+using namespace planning_scene;
+using namespace moveit::core;
+
+// https://github.com/moveit/moveit_task_constructor/issues/638
+TEST(SolutionMsg, DuplicateScenes) {
+	Task t;
+	PlanningScenePtr scene;
+
+	t.setRobotModel(getModel());
+	scene = std::make_shared<PlanningScene>(t.getRobotModel());
+	t.add(std::make_unique<stages::FixedState>("start", scene));
+
+	EXPECT_TRUE(t.plan(1));
+	EXPECT_EQ(t.solutions().size(), 1u);
+
+	// create solution
+	moveit_task_constructor_msgs::Solution solution_msg;
+	t.solutions().front()->toMsg(solution_msg);
+
+	// all sub trajectories `scene_diff` should be a diff
+	EXPECT_EQ(solution_msg.sub_trajectory.size(), 1u);
+	EXPECT_EQ(solution_msg.start_scene.is_diff, false);
+	EXPECT_EQ(solution_msg.sub_trajectory.front().scene_diff.is_diff, true);
+}


### PR DESCRIPTION
Fixes #638.

I'm not sure if this has other implications.

----
**EDIT**

> That's a cheap (in terms of lines of code) solution indeed. 👍 It is quite costly with meshes in the scene

Actually that is currently my problem as I have multiple meshes. While it adds only 17ms, this will be passed to the controller which will add more CPU time. And finally, I recompute the PlanningScene object from the msg, in a queue, to be able to set the planning scene (FixedState stage) for subsequent  MTC Tasks. Without this fix I loose 3 seconds from applying the scene msg diff that is already up to date.
