### PR TITLE
Call reset before initializing the task

### DIFF
--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -248,6 +248,7 @@ moveit::core::MoveItErrorCode Task::plan(size_t max_solutions) {
 	auto guard = sg::make_scope_guard([this]() noexcept { this->resetPreemptRequest(); });
 
 	auto impl = pimpl();
+	reset();
 	init();
 
 	// Print state and return success if there are solutions otherwise the input error_code


### PR DESCRIPTION
@henrygerardmoore @rhaschke  I have been investigating this [issue](https://github.com/moveit/moveit_task_constructor/issues/630) where calling `plan()` on the same task more than once can lead to a segfault. The is some internal state the task that is modified during planning, which causes subsequent planning to fail. For example, the `states_`  field of `StagePrivate` contained some values from the last run on the subsequent run. My solution is to call the `reset()` method on the MTC Task object before calling `init()` and planning. This fixed the segfault we were seeing and also generated valid plans.

Let me know if this is a suitable solution or if there is another recommended way to avoid stale task objects causing failures. 