### PR TITLE
Add feedback to ExecuteTaskSolution action

### DIFF
--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -123,7 +123,7 @@ void ExecuteTaskSolutionCapability::execCallback(
 	// iterate over the subtrajectories and execute them one by one
 	for (size_t i = 0; i < plan.plan_components.size(); ++i) {
 		plan_execution::ExecutableMotionPlan sub_plan;
-		sub_plan.plan_components = {plan.plan_components[i]};
+		sub_plan.plan_components = { plan.plan_components[i] };
 
 		const auto exec_result = context_->plan_execution_->executeAndMonitor(sub_plan);
 		if (exec_result.val == moveit_msgs::msg::MoveItErrorCodes::PREEMPTED && goal_handle->is_canceling()) {


### PR DESCRIPTION
Addresses https://github.com/moveit/moveit_task_constructor/issues/475: adding feedback to the ExecuteTaskSolution action. 

Instead of executing all subtrajectories at once, we now execute them sequentially and publish feedback after each subtrajectory finished successfully. Actually, **this approach revealed a hidden issue**: the `allowed_start_tolerance` was only checked once at the beginning of the task, not for each subtrajectory. I discovered this after one of our joints started to fail in one stage (this is one of the main reasons of this port https://github.com/moveit/moveit2/pull/3309).

I'm aware that calling `executeAndMonitor` for each subtrajectory may have performance implications. However, as far as I could test it in our setup, I didn't see much difference. What do you think? Maybe in case it matters we should add a parameter to allow/disallow publishing feedback. However, in that case, we should address the issue previously mentioned.

Since these changes are highly ROS-dependent and I’ve only tested them in ROS2, this PR targets the `ros2` branch. Once approved, it should be straightforward to submit another PR for backporting the changes to `main` for ROS1.