### PR TITLE
Add node name remap rule for rviz2

### DIFF
--- a/demo/launch/demo.launch.py
+++ b/demo/launch/demo.launch.py
@@ -37,9 +37,8 @@ def generate_launch_description():
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
         output="log",
-        arguments=["-d", rviz_config_file],
+        arguments=["-d", rviz_config_file, "--ros-args", "--remap", "rviz:__name:=rviz2"],
         parameters=[
             moveit_config.robot_description,
             moveit_config.robot_description_semantic,


### PR DESCRIPTION
Address https://github.com/moveit/moveit2_tutorials/issues/991 where two nodes are launched with same name rviz2. 

This is companion PR for https://github.com/moveit/moveit2_tutorials/pull/1030. 