### PR TITLE
Add ability to preempt execution and add test

### DIFF
--- a/capabilities/CMakeLists.txt
+++ b/capabilities/CMakeLists.txt
@@ -34,6 +34,8 @@ install(TARGETS ${PROJECT_NAME}
   LIBRARY DESTINATION lib
 )
 
+add_subdirectory(test)
+
 pluginlib_export_plugin_description_file(moveit_ros_move_group capabilities_plugin_description.xml)
 ament_export_dependencies(moveit_core)
 ament_export_dependencies(moveit_ros_move_group)

--- a/capabilities/test/CMakeLists.txt
+++ b/capabilities/test/CMakeLists.txt
@@ -1,0 +1,15 @@
+#############
+## Testing ##
+#############
+
+## Add gtest based cpp test target
+if (BUILD_TESTING)
+	find_package(ament_cmake_gtest REQUIRED)
+	find_package(launch_testing_ament_cmake REQUIRED)
+	find_package(moveit_task_constructor_core REQUIRED)
+
+	ament_add_gtest_executable(test_execution test_task_execution.cpp)
+	add_launch_test(test_execution.launch.py TARGET test_execution
+										ARGS "test_binary:=$<TARGET_FILE:test_execution>")
+	ament_target_dependencies(test_execution moveit_task_constructor_core)
+endif()

--- a/capabilities/test/test_execution.launch.py
+++ b/capabilities/test/test_execution.launch.py
@@ -1,0 +1,77 @@
+import unittest
+import os
+
+from ament_index_python.packages import get_package_share_directory
+import launch_testing
+import pytest
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_testing.actions import ReadyToTest
+from launch_testing.util import KeepAliveProc
+from moveit_configs_utils import MoveItConfigsBuilder
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    moveit_config = (
+        MoveItConfigsBuilder("moveit_resources_panda")
+        .robot_description(file_path="config/panda.urdf.xacro")
+        .to_moveit_configs()
+    )
+
+    demo_bringup = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("moveit_task_constructor_demo"), "launch/demo.launch.py"
+            )
+        ),
+        launch_arguments={"rviz": "false"}.items(),
+    )
+
+    # increase the timeout for the kinematics solver to fix flaky IK for asan
+    k = moveit_config.robot_description_kinematics["robot_description_kinematics"]
+    k["panda_arm"]["kinematics_solver_timeout"] = 5.0
+
+    test_exec = Node(
+        executable=[
+            LaunchConfiguration("test_binary"),
+        ],
+        output="screen",
+        parameters=[
+            moveit_config.robot_description,
+            moveit_config.robot_description_semantic,
+            moveit_config.robot_description_kinematics,
+            moveit_config.joint_limits,
+        ],
+    )
+
+    return (
+        LaunchDescription(
+            [
+                demo_bringup,
+                DeclareLaunchArgument(
+                    name="test_binary",
+                    description="Test executable",
+                ),
+                test_exec,
+                KeepAliveProc(),
+                ReadyToTest(),
+            ]
+        ),
+        {"test_exec": test_exec},
+    )
+
+
+class TestTerminatingProcessStops(unittest.TestCase):
+    def test_gtest_run_complete(self, proc_info, test_exec):
+        proc_info.assertWaitForShutdown(process=test_exec, timeout=4000.0)
+
+
+@launch_testing.post_shutdown_test()
+class TaskModelTestAfterShutdown(unittest.TestCase):
+    def test_exit_code(self, proc_info):
+        # Check that all processes in the launch exit with code 0
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/capabilities/test/test_task_execution.cpp
+++ b/capabilities/test/test_task_execution.cpp
@@ -1,0 +1,72 @@
+#include <moveit/task_constructor/task.h>
+#include <moveit/task_constructor/stages/current_state.h>
+#include <moveit/task_constructor/stages/move_to.h>
+#include <moveit/task_constructor/solvers/joint_interpolation.h>
+#include <moveit_task_constructor_msgs/msg/solution.hpp>
+#include <moveit/robot_model/robot_model.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace moveit::task_constructor;
+
+// provide a basic test fixture that prepares a Task
+struct PandaMoveTo : public testing::Test
+{
+	Task t;
+	stages::MoveTo* move_to;
+	rclcpp::Node::SharedPtr node;
+
+	PandaMoveTo() {
+		node = rclcpp::Node::make_shared("panda_move_to");
+		t.loadRobotModel(node);
+
+		auto group = t.getRobotModel()->getJointModelGroup("panda_arm");
+
+		auto initial = std::make_unique<stages::CurrentState>("current state");
+		t.add(std::move(initial));
+
+		auto move = std::make_unique<stages::MoveTo>("move", std::make_shared<solvers::JointInterpolationPlanner>());
+		move_to = move.get();
+		move_to->setGroup(group->getName());
+		t.add(std::move(move));
+	}
+};
+
+// The arm starts in the "ready" pose so make sure we can move to a different known location
+TEST_F(PandaMoveTo, successExecution) {
+	move_to->setGoal("extended");
+	EXPECT_TRUE(t.plan());
+	auto execute_result = t.execute(*t.solutions().front());
+	EXPECT_TRUE(execute_result.val == moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
+}
+
+// After the arm successfully moves to "extended" try to move back to "ready" and make sure preempt() woks as expected
+TEST_F(PandaMoveTo, preemptExecution) {
+	move_to->setGoal("ready");
+	EXPECT_TRUE(t.plan());
+	// extract the expected execution time (for this task its in the last sub_trajectory)
+	moveit_task_constructor_msgs::msg::Solution s;
+	t.solutions().front()->toMsg(s, nullptr);
+	auto exec_duration = s.sub_trajectory.back().trajectory.joint_trajectory.points.back().time_from_start;
+
+	moveit::core::MoveItErrorCode execute_result;
+	execute_result.val = execute_result.UNDEFINED;
+	std::thread execute_thread{ [this, &execute_result]() { execute_result = t.execute(*t.solutions().front()); } };
+	// cancel the trajectory half way through the expected execution time
+	rclcpp::sleep_for(std::chrono::duration_cast<std::chrono::nanoseconds>(
+	    (std::chrono::seconds(exec_duration.sec) + std::chrono::nanoseconds(exec_duration.nanosec)) / 2));
+	t.preempt();
+	execute_thread.join();
+
+	EXPECT_TRUE(execute_result.val == moveit_msgs::msg::MoveItErrorCodes::PREEMPTED);
+}
+
+int main(int argc, char** argv) {
+	testing::InitGoogleTest(&argc, argv);
+	rclcpp::init(argc, argv);
+
+	// wait some time for move_group to come up
+	rclcpp::sleep_for(std::chrono::seconds(2));
+
+	return RUN_ALL_TESTS();
+}

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -167,6 +167,8 @@ protected:
 
 private:
 	using WrapperBase::init;
+	// persistent node to call the ExecuteTaskSolution action and is only created if execute() is called
+	rclcpp::Node::SharedPtr execute_solution_node_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Task& task) {

--- a/core/include/moveit/task_constructor/task.h
+++ b/core/include/moveit/task_constructor/task.h
@@ -43,6 +43,7 @@
 
 #include <moveit/task_constructor/introspection.h>
 #include <moveit_task_constructor_msgs/msg/solution.hpp>
+#include <moveit_task_constructor_msgs/action/execute_task_solution.hpp>
 
 #include <moveit/macros/class_forward.hpp>
 
@@ -50,6 +51,7 @@
 #include <moveit/utils/moveit_error_code.hpp>
 
 #include <rclcpp/node.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
 
 namespace moveit {
 namespace core {
@@ -167,8 +169,9 @@ protected:
 
 private:
 	using WrapperBase::init;
-	// persistent node to call the ExecuteTaskSolution action and is only created if execute() is called
+	// persistent node and client to call the ExecuteTaskSolution action and is only created if execute() is called
 	rclcpp::Node::SharedPtr execute_solution_node_;
+	std::shared_ptr<rclcpp_action::Client<moveit_task_constructor_msgs::action::ExecuteTaskSolution>> execute_ac_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const Task& task) {

--- a/demo/launch/demo.launch.py
+++ b/demo/launch/demo.launch.py
@@ -2,12 +2,18 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
+from launch.actions import ExecuteProcess, DeclareLaunchArgument
+from launch.conditions import IfCondition
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from moveit_configs_utils import MoveItConfigsBuilder
 
 
 def generate_launch_description():
+    declared_arguments = []
+    declared_arguments.append(
+        DeclareLaunchArgument("rviz", default_value="true", description="Launch RViz?")
+    )
     moveit_config = (
         MoveItConfigsBuilder("moveit_resources_panda")
         .planning_pipelines(pipelines=["ompl"])
@@ -31,6 +37,7 @@ def generate_launch_description():
     )
 
     # RViz
+    launch_rviz = LaunchConfiguration("rviz")
     rviz_config_file = (
         get_package_share_directory("moveit_task_constructor_demo") + "/config/mtc.rviz"
     )
@@ -45,6 +52,7 @@ def generate_launch_description():
             moveit_config.robot_description_kinematics,
             moveit_config.planning_pipelines,
         ],
+        condition=IfCondition(launch_rviz),
     )
 
     # Static TF
@@ -94,7 +102,8 @@ def generate_launch_description():
         ]
 
     return LaunchDescription(
-        [
+        declared_arguments
+        + [
             rviz_node,
             static_tf,
             robot_state_publisher,


### PR DESCRIPTION
This PR is an update of #363 and adds a test to ensure it is working as expected.

Additional changes I made to make it possible:
- Added the ability to not start Rviz when running demo.launch.py (I use this launch file in my test and needed the ability to disable it)
- Added a persistent node and action client to `Task`
Extended testing of my motion system has found that recreating the node on each execution request can cause a seg fault after many hours of running. I am continuing to test this and will update with any results, but if you feel this is out of scope I can move this feature to a different PR. Here is a link to the [upstream issue](https://github.com/eclipse-cyclonedds/cyclonedds/issues/2022) with cyclonedds and changes they have made.
```
[my_motion_node-9] my_motion_node: ./src/core/ddsc/src/dds_handles.c:430: dds_handle_drop_childref_and_pin: Assertion `(cf & HDL_REFCOUNT_MASK) > 0' failed.
[my_motion_node-9] Stack trace (most recent call last) in thread 686402:
[my_motion_node-9] #27   Object "/usr/lib/aarch64-linux-gnu/ld-linux-aarch64.so.1", at 0xffffffffffffffff, in 
[my_motion_node-9] #26   Object "/usr/lib/aarch64-linux-gnu/libc.so.6", at 0xffffb3adba4b, in 
[my_motion_node-9] #25   Object "/usr/lib/aarch64-linux-gnu/libc.so.6", at 0xffffb3a7595b, in 
[my_motion_node-9] #24   Object "/usr/lib/aarch64-linux-gnu/libstdc++.so.6.0.33", at 0xffffb3d81adf, in 
...
[my_motion_node-9] #19   Object "/root/ws/install/my_motion_node", at 0xaaaad172b93b, in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold()
[my_motion_node-9] #18   Object "/root/ws/install/my_motion_node", at 0xaaaad176fff7, in std::_Sp_counted_deleter<rclcpp_action::Client<moveit_task_constructor_msgs::action::ExecuteTaskSolution>*, rclcpp_action::create_client<moveit_task_constructor_msgs::action::ExecuteTaskSolution>(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeWaitablesInterface>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<rclcpp::CallbackGroup>, rcl_action_client_options_s const&)::{lambda(rclcpp_action::Client<moveit_task_constructor_msgs::action::ExecuteTaskSolution>*)#1}, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose()
[my_motion_node-9] #17   Object "/root/ws/install/my_motion_node", at 0xaaaad176f58f, in rclcpp_action::create_client<moveit_task_constructor_msgs::action::ExecuteTaskSolution>(std::shared_ptr<rclcpp::node_interfaces::NodeBaseInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeGraphInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeLoggingInterface>, std::shared_ptr<rclcpp::node_interfaces::NodeWaitablesInterface>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::shared_ptr<rclcpp::CallbackGroup>, rcl_action_client_options_s const&)::{lambda(rclcpp_action::Client<moveit_task_constructor_msgs::action::ExecuteTaskSolution>*)#1}::operator()(rclcpp_action::Client<moveit_task_constructor_msgs::action::ExecuteTaskSolution>*) const
```