### PR TITLE
Add functions for adding markers to solutions

### DIFF
--- a/core/include/moveit/task_constructor/introspection.h
+++ b/core/include/moveit/task_constructor/introspection.h
@@ -105,6 +105,17 @@ public:
 	/// retrieve or set id of given solution
 	uint32_t solutionId(const moveit::task_constructor::SolutionBase& s);
 
+	/// add markers to a solution
+	void addMarkers(const uint id, const std::vector<visualization_msgs::msg::Marker>& markers);
+
+	void addMarkers(const moveit::task_constructor::SolutionBase& s,
+	                const std::vector<visualization_msgs::msg::Marker>& markers);
+
+	/// reset markers
+	void resetMarkers(const uint id);
+
+	void resetAllMarkers();
+
 private:
 	void fillStageStatistics(const Stage& stage, moveit_task_constructor_msgs::msg::StageStatistics& s);
 	void fillSolution(moveit_task_constructor_msgs::msg::Solution& msg, const SolutionBase& s);

--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -163,6 +163,9 @@ public:
 	/// mapping from stages to their id
 	std::map<const StagePrivate*, moveit_task_constructor_msgs::msg::StageStatistics::_id_type> stage_to_id_map_;
 	boost::bimap<uint32_t, const SolutionBase*> id_solution_bimap_;
+
+	/// mapping from solution id to added visualization markers
+	std::map<uint, std::vector<visualization_msgs::msg::Marker>> solution_id_to_markers_map_;
 };
 
 Introspection::Introspection(const TaskPrivate* task) : impl(new IntrospectionPrivate(task, this)) {}
@@ -260,6 +263,23 @@ void Introspection::fillStageStatistics(const Stage& stage, moveit_task_construc
 
 	s.total_compute_time = stage.getTotalComputeTime();
 	s.num_failed = stage.numFailures();
+}
+
+void Introspection::addMarkers(const uint id, const std::vector<visualization_msgs::msg::Marker>& markers) {
+	impl->solution_id_to_markers_map_[id] = markers;
+}
+
+void Introspection::addMarkers(const moveit::task_constructor::SolutionBase& s,
+                               const std::vector<visualization_msgs::msg::Marker>& markers) {
+	addMarkers(solutionId(s), markers);
+}
+
+void Introspection::resetMarkers(const uint id) {
+	impl->solution_id_to_markers_map_[id].clear();
+}
+
+void Introspection::resetAllMarkers() {
+	impl->solution_id_to_markers_map_.clear();
 }
 
 moveit_task_constructor_msgs::msg::TaskDescription&


### PR DESCRIPTION
Add and reset marker management functions in Introspection

- `addMarkers`: Associates a vector of visualization markers with a solution, either by solution ID or by SolutionBase reference.
- `resetMarkers`: Clears all markers associated with a specific solution ID.
- `resetAllMarkers`: Clears all stored markers for all solutions.

These functions enable storing, updating, and clearing visualization markers for solutions.