### PR TITLE
Reset preempt_request after canceling execution

### DIFF
--- a/capabilities/test/test_task_execution.cpp
+++ b/capabilities/test/test_task_execution.cpp
@@ -60,6 +60,12 @@ TEST_F(PandaMoveTo, preemptExecution) {
 	}
 
 	EXPECT_EQ(result.val, moveit_msgs::msg::MoveItErrorCodes::PREEMPTED);
+
+	// After preempting motion reset the task and make sure we can successfully plan and execute motion again
+	t.reset();
+	ASSERT_TRUE(t.plan());
+	result = t.execute(*t.solutions().front());
+	EXPECT_EQ(result.val, moveit_msgs::msg::MoveItErrorCodes::SUCCESS);
 }
 
 int main(int argc, char** argv) {

--- a/capabilities/test/test_task_execution.cpp
+++ b/capabilities/test/test_task_execution.cpp
@@ -62,6 +62,7 @@ TEST_F(PandaMoveTo, preemptExecution) {
 	EXPECT_EQ(result.val, moveit_msgs::msg::MoveItErrorCodes::PREEMPTED);
 
 	// After preempting motion reset the task and make sure we can successfully plan and execute motion again
+	rclcpp::sleep_for(std::chrono::seconds(1));
 	t.reset();
 	ASSERT_TRUE(t.plan());
 	result = t.execute(*t.solutions().front());

--- a/core/src/task.cpp
+++ b/core/src/task.cpp
@@ -316,6 +316,7 @@ moveit::core::MoveItErrorCode Task::execute(const SolutionBase& s) {
 	while (result_future.wait_for(std::chrono::milliseconds(10)) != std::future_status::ready) {
 		if (pimpl()->preempt_requested_) {
 			auto cancel_future = execute_ac_->async_cancel_goal(goal_handle);
+			this->resetPreemptRequest();
 			if (rclcpp::spin_until_future_complete(execute_solution_node_, cancel_future) !=
 			    rclcpp::FutureReturnCode::SUCCESS) {
 				RCLCPP_ERROR(execute_solution_node_->get_logger(), "Could not preempt execution");


### PR DESCRIPTION
Integrating preempt execution into my downstream application I found that when reusing my Task object between requests it would fail planning after preempting motion because the `preempt_requested_` flag was never reset. Sorry for missing this in #684 I thought the flag was reset on each `plan()` request but it looks like #597 has some use case where that causes issues.
