### PR TITLE
Enable use of properties::_class::property for custom python bindings

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -19,8 +19,6 @@ jobs:
       - name: Install clang-format-14
         run: sudo apt-get install clang-format-14
       - uses: rhaschke/install-catkin_lint-action@main
-        with:
-          distro: noetic
       - uses: pre-commit/action@v3.0.1
         id: precommit
       - name: Upload pre-commit changes

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.1.0
     hooks:
       - id: black
         args: ["--line-length", "100"]

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -27,6 +27,7 @@ catkin_package(
 		${PROJECT_NAME}
 		${PROJECT_NAME}_stages
 		${PROJECT_NAME}_stage_plugins
+		${PROJECT_NAME}_python_tools
 	INCLUDE_DIRS
 		include
 	CATKIN_DEPENDS

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -39,7 +39,7 @@ catkin_package(
 	CFG_EXTRAS pybind11.cmake
 )
 
-add_compile_options(-fvisibility-inlines-hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN TRUE)
 
 set(PROJECT_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include/moveit/task_constructor)
 

--- a/core/python/CMakeLists.txt
+++ b/core/python/CMakeLists.txt
@@ -3,9 +3,6 @@
 # pybind11 must use the ROS python version
 set(PYBIND11_PYTHON_VERSION ${PYTHON_VERSION})
 
-# Use minimum-size optimization for pybind11 bindings
-add_compile_options("-Os")
-
 # create symlink to grant access to downstream packages in devel space
 add_custom_target(pybind11_devel_symlink ALL COMMAND ${CMAKE_COMMAND} -E create_symlink
 	${CMAKE_CURRENT_SOURCE_DIR}/pybind11

--- a/core/python/bindings/CMakeLists.txt
+++ b/core/python/bindings/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(${PROJECT_NAME}_python_tools SHARED
 	src/properties.cpp
 )
 target_link_libraries(${PROJECT_NAME}_python_tools PUBLIC ${PROJECT_NAME} pybind11::pybind11)
+# Use minimum-size optimization for pybind11 bindings
+target_link_libraries(${PROJECT_NAME}_python_tools PUBLIC pybind11::opt_size)
 
 # catkin_lint cannot detect target declarations in functions, here in pybind11_add_module
 #catkin_lint: ignore undefined_target

--- a/core/python/bindings/CMakeLists.txt
+++ b/core/python/bindings/CMakeLists.txt
@@ -1,22 +1,26 @@
+set(INCLUDES ${PROJECT_SOURCE_DIR}/include/moveit/python/task_constructor)
+add_library(${PROJECT_NAME}_python_tools SHARED
+	${INCLUDES}/properties.h
+	src/properties.cpp
+)
+target_link_libraries(${PROJECT_NAME}_python_tools PUBLIC ${PROJECT_NAME} pybind11::pybind11)
+
 # catkin_lint cannot detect target declarations in functions, here in pybind11_add_module
 #catkin_lint: ignore undefined_target
 
 # moveit.task_constructor
-set(INCLUDES ${PROJECT_SOURCE_DIR}/include/moveit/python/task_constructor)
 pybind11_add_module(pymoveit_mtc
-	${INCLUDES}/properties.h
-
-	src/properties.cpp
 	src/solvers.cpp
 	src/core.cpp
 	src/stages.cpp
 	src/module.cpp
 )
-target_include_directories(pymoveit_mtc PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
-target_link_libraries(pymoveit_mtc PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_stages ${TOOLS_LIB_NAME})
+target_link_libraries(pymoveit_mtc PUBLIC ${PROJECT_NAME} ${PROJECT_NAME}_stages ${PROJECT_NAME}_python_tools)
 set_target_properties(pymoveit_mtc PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_GLOBAL_PYTHON_DESTINATION})
 
-# install python libs
+# install libs
+install(TARGETS ${PROJECT_NAME}_python_tools
+	ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+	LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
 install(TARGETS pymoveit_mtc
-	LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION}
-)
+	LIBRARY DESTINATION ${CATKIN_GLOBAL_PYTHON_DESTINATION})

--- a/core/python/bindings/src/properties.cpp
+++ b/core/python/bindings/src/properties.cpp
@@ -155,6 +155,7 @@ bool PropertyConverterBase::insert(const std::type_index& type_index, const std:
 	return REGISTRY_SINGLETON.insert(type_index, ros_msg_name, to, from);
 }
 
+__attribute__((visibility("default"))) // export this symbol as visible in the shared library
 void export_properties(py::module& m) {
 	// clang-format off
 	py::classh<Property>(m, "Property", "Holds an arbitrarily typed value and a default value")


### PR DESCRIPTION
Using this method in custom bindings results in an undefined symbol error for `PropertyConverterBase::insert`, which is defined in the `pymoveit_mtc` extension. 
To allow linking all relevant classes and functions, I factored out these components into a new shared library `libmoveit_task_constructor_core_python_tools.so`, which is exported by the catkin package.