### PR TITLE
fmt/ranges.h added in execute_task_solution_capability.cpp

### DIFF
--- a/capabilities/src/execute_task_solution_capability.cpp
+++ b/capabilities/src/execute_task_solution_capability.cpp
@@ -44,6 +44,7 @@
 #include <moveit/utils/message_checks.h>
 #include <moveit/utils/moveit_error_code.h>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 
 namespace {
 


### PR DESCRIPTION
This PR resolves the build errors by adding the missing `#include <fmt/ranges.h>` where `fmt::join` is used.